### PR TITLE
fix: OpenCPNのDockerビルド停止問題を修正

### DIFF
--- a/docker/navi-devices/opencpn/Dockerfile
+++ b/docker/navi-devices/opencpn/Dockerfile
@@ -1,11 +1,12 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
-RUN apt-get update \
-&&  apt-get install -y software-properties-common \
-&&  add-apt-repository --yes ppa:opencpn/opencpn \
-&&  apt-get update \
-&&  apt-get install -y \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     opencpn \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     x11vnc \
     xvfb \
     fluxbox \
@@ -14,7 +15,7 @@ RUN apt-get update \
     net-tools \
     supervisor \
     iproute2 \
-&&  rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
 # noVNC用のリンク作成
 RUN ln -s /usr/share/novnc/vnc.html /usr/share/novnc/index.html


### PR DESCRIPTION
## 概要

OpenCPN 用 Docker イメージのビルド時に停止する問題を修正しました。

これまで `software-properties-common` と `add-apt-repository` を使用して OpenCPN の PPA を追加していましたが、この処理により `packagekit` / `polkitd` / `dbus` 関連の後処理が発生し、Docker build 環境で処理が停止することがありました。

## 変更内容

- `software-properties-common` のインストールを削除
- `add-apt-repository ppa:opencpn/opencpn` を削除
- Ubuntu 22.04 の標準リポジトリから `opencpn` を直接インストールする構成に変更
- PPA 追加処理に依存しない Dockerfile に修正

## 確認内容

- Docker イメージのビルドが正常に完了することを確認
- `Processing triggers for dbus ...` で停止しないことを確認
- noVNC 関連パッケージのインストール処理に進むことを確認

## 影響範囲

OpenCPN の取得元が PPA から Ubuntu 22.04 標準リポジトリに変わります。  
そのため、PPA 版より OpenCPN のバージョンが古くなる可能性があります。